### PR TITLE
Visualize collapsable elements

### DIFF
--- a/css/railroad.css
+++ b/css/railroad.css
@@ -11,6 +11,8 @@
  * Don't ask me for permission to use any part of this project, JUST USE IT.
  * I would appreciate attribution, but that is not required by the license.
  */
+
+ /* These styles are contained in the original railroad.css but may have been modified */
 svg.railroad-diagram {
 	background-color: hsl(30,20%,95%);
 }
@@ -66,11 +68,12 @@ svg.railroad-diagram .non-terminal:hover rect {
 	stroke: black;
 	fill: hsl(120, 100%, 75%);
 }
-
 svg.railroad-diagram text:hover {
 	cursor: default;
 }
-
 svg.railroad-diagram .non-terminal:hover text {
+	cursor: pointer;
+}
+svg.railroad-diagram text.comment:hover {
 	cursor: pointer;
 }

--- a/css/railroad.css
+++ b/css/railroad.css
@@ -74,6 +74,12 @@ svg.railroad-diagram text:hover {
 svg.railroad-diagram .non-terminal:hover text {
 	cursor: pointer;
 }
-svg.railroad-diagram text.comment:hover {
+svg.railroad-diagram g.comment:hover text {
 	cursor: pointer;
+}
+svg.railroad-diagram g.comment text.collapseX{
+	display: none;
+}
+svg.railroad-diagram g.comment:hover text.collapseX {
+	display: block;
 }

--- a/src/railroad.js
+++ b/src/railroad.js
@@ -16,6 +16,7 @@ I would appreciate attribution, but that is not required by the license.
 /*
 Notes on changes I made to the original code:
 * Added the ability to pass a "title" to the Group-class, which interallly passes it to the Comment-class.
+* Add "x" next to comment text so it can be collapsed on click.
 */
 
 // Export function versions of all the constructors.
@@ -1894,8 +1895,11 @@ export class Comment extends FakeSVG {
 		var text = new FakeSVG('text', {x:x+this.width/2, y:y+5, class:'comment'}, this.text);
 		if(this.href)
 			new FakeSVG('a', {'xlink:href': this.href}, [text]).addTo(this);
-		else
+		else {
 			text.addTo(this);
+			let collapseX = new FakeSVG('text', {x:x+this.width + 5, y:y+5, class:'collapseX'}, ["&#11198;"]); // The "⮾" symbol next to the comment
+			collapseX.addTo(this);
+		}
 		if(this.title)
 			new FakeSVG('title', {}, this.title).addTo(this);
 		return this;


### PR DESCRIPTION
Add a small `⮾` next to the extended NTS name when hovered. Also adjust the cursor on hover