### PR TITLE
Encode grammar and extended list into URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ Name = an { an } .
 ```
 ![Example railroad diagram for given grammar](./images/basic_railroad_diagram.svg)
 
+Try it out yourself with this [LINK](https://wtf-my-code.works/rr-diagram//index.html?grammar=UGF0aCA9IERpciB7IERpciB9IE5hbWUgLgpEaXIgPSAoIE5hbWUgfCAiLiIgWyAiLiIgXSApICIvIiAuCk5hbWUgPSBhbiB7IGFuIH0gLg).
+
 ## Features
 * **Error Information:** In the case that an error occurs during scanning or parsing of the input grammar, a small description is written below the grammar as shown:  
 ![Example of message for faulty grammar](./images/faulty_grammar_input.jpg)
 
 * **NTS Expansion:** NTS are displayed as rectangles and can be expanded by clicking them. The definition of the NTS is then displayed in a dashed box as shown:  
 ![Example railroad diagram with expanded NTS](./images/expanded_railroad_diagram.svg)
+
+* **URL Encoded Grammar:** Grammar is base64URL encoded into the URL. This allows for easy sharing of the current grammar by copying the URL or bookmarking it.
 
 ## TODOs
 * Make UI nicer and a bit more user-friendly. Maybe also add some instructions and a dark mode 🌕

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Try it out yourself with this [LINK](https://wtf-my-code.works/rr-diagram//index
 * **NTS Expansion:** NTS are displayed as rectangles and can be expanded by clicking them. The definition of the NTS is then displayed in a dashed box as shown:  
 ![Example railroad diagram with expanded NTS](./images/expanded_railroad_diagram.svg)
 
-* **URL Encoded Grammar:** Grammar is base64URL encoded into the URL. This allows for easy sharing of the current grammar by copying the URL or bookmarking it.
+* **URL Encoded Grammar:** Grammar is base64URL encoded into the URL. This allows for easy sharing of the current grammar by copying the URL or bookmarking it. The encoding also includes the list of expanded NTS.
 
 ## TODOs
 * Make UI nicer and a bit more user-friendly. Maybe also add some instructions and a dark mode 🌕

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
 
               // Generate the diagram again
               generateDiagram();
+              updateURL();
             });
           });
 
@@ -58,6 +59,7 @@
 
               // Generate the diagram again
               generateDiagram();
+              updateURL();
             });
           });
 
@@ -94,6 +96,7 @@
 				toExtend.clear();
 				// Generate the diagram again
 				generateDiagram();
+        updateURL();
 			}
 
       /**
@@ -107,6 +110,7 @@
         asyncGenerateGrammar(ebnfGrammarValue).then((g) => {
           toExtend = new Set(g.expandableIDs);
           generateDiagram();
+          updateURL();
         }).catch((e) =>  console.warn(e));
         // Generate the diagram again
       }
@@ -145,18 +149,50 @@
         });
       }
 
+      // Update URL with grammar and expand numbers
       window.updateURL = function() {
+        let url = new URL(window.location.href)
+
         let grammar = document.querySelector("textarea[name=ebnf_grammar]").value;
-        let url = window.location.origin + window.location.pathname + "?grammar=" + base64UrlEncode(grammar);
-        window.history.replaceState({}, "", url);
+        if (grammar.trim() === "") {
+          // Remove grammar from URL
+          url.searchParams.delete("grammar");
+        } else {
+          //  Encode grammar to base64URL and add to URL
+          let grammarBase64 = base64UrlEncode(grammar);
+          url.searchParams.set("grammar", grammarBase64);
+        }
+
+        if (toExtend.size === 0) {
+          // Remove expand numbers from URL
+          url.searchParams.delete("expand");
+        } else {
+          // Add expand numbers to URL
+          url.searchParams.set("expand", Array.from(toExtend).join("|"));
+        }
+
+        // Replace URL
+        window.history.replaceState({}, "", url.toString());
       }
 
       window.onload = function() {
+        // Try to get grammar from URL
         let urlGrammar = new URLSearchParams(window.location.search).get("grammar");
         if(urlGrammar) {
           let grammar = base64UrlDecode(urlGrammar)
           document.querySelector("textarea[name=ebnf_grammar]").value = grammar;
-          window.handleGenerateDiagram();
+        }
+
+        // Try to get toExpand numbers from URL
+        let urlToExpandNumbers = new URLSearchParams(window.location.search).get("expand");
+        if(urlToExpandNumbers) {
+          let toExpandNumbers = urlToExpandNumbers.split("|").map(Number);
+          toExtend = new Set(toExpandNumbers);
+        }
+
+        if (urlGrammar || urlToExpandNumbers) {
+          // Generate diagram when something is in the URL
+          generateDiagram();
         }
       }
     </script>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="./css/styles.css">
     <script type="module">
       import { Diagram } from "./out/Diagram.js";
-      import { asyncGenerateDiagram, asyncGenerateGrammar, asyncCssToString } from "./out/ChooChoo.js";
+      import { asyncGenerateDiagram, asyncGenerateGrammar, asyncCssToString, base64UrlEncode, base64UrlDecode } from "./out/ChooChoo.js";
       let toExtend = new Set();
 
 			function generateDiagram() {
@@ -81,6 +81,7 @@
 			window.handleGenerateDiagram = function() {
 				toExtend.clear();
 				generateDiagram();
+        updateURL();
 			}
 
 
@@ -142,6 +143,21 @@
           a.download = "railroad-diagram.svg";
           a.click();
         });
+      }
+
+      window.updateURL = function() {
+        let grammar = document.querySelector("textarea[name=ebnf_grammar]").value;
+        let url = window.location.origin + window.location.pathname + "?grammar=" + base64UrlEncode(grammar);
+        window.history.replaceState({}, "", url);
+      }
+
+      window.onload = function() {
+        let urlGrammar = new URLSearchParams(window.location.search).get("grammar");
+        if(urlGrammar) {
+          let grammar = base64UrlDecode(urlGrammar)
+          document.querySelector("textarea[name=ebnf_grammar]").value = grammar;
+          window.handleGenerateDiagram();
+        }
       }
     </script>
   </head>

--- a/src/ChooChoo.ts
+++ b/src/ChooChoo.ts
@@ -113,3 +113,31 @@ export async function asyncCssToString(styleSheet: CSSStyleSheet): Promise<strin
 		}
 	});
 }
+
+/**
+ * Encode a string to base64URL.
+ * It internally replaces the characters `+`, `/` and `=` with `-`, `_` to avoid percentage encoding in URL
+ * @param toEncode The string to encode
+ * @returns The base64URL encoded string
+ */
+export function base64UrlEncode(toEncode: string): string {
+	return btoa(toEncode)
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=/g, '');
+}
+
+/**
+ * Decode a base64URL encoded string.
+ * @param toDecode The base64URL encoded string to decode
+ * @returns The decoded string
+ */
+export function base64UrlDecode(toDecode: string): string {
+	let base64 = toDecode
+		.replace(/-/g, '+')
+		.replace(/_/g, '/');
+	while (base64.length % 4 !== 0) {
+		base64 += '=';
+	}
+	return atob(base64);
+}


### PR DESCRIPTION
The grammar is encoded as base64URL. The list of numbers is separated by `|`-symbols.

This allows easy sharing of created diagrams by using the URL.