### PR TITLE
Fix number and invalid character issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="./css/styles.css">
     <script type="module">
       import { Diagram } from "./out/Diagram.js";
-      import { asyncGenerateDiagram, asyncGenerateGrammar, asyncCssToString, base64UrlEncode } from "./out/ChooChoo.js";
+      import { asyncGenerateDiagram, asyncGenerateGrammar, asyncCssToString, base64UrlEncode, getNonAsciiChars } from "./out/ChooChoo.js";
       let toExtend = new Set();
 
 
@@ -24,6 +24,14 @@
           diagram_container.style.display = "none";
 					return;
 				}
+        let nonAscii = getNonAsciiChars(ebnfGrammarValue);
+        if (nonAscii.size > 0) {
+          console.warn("The following non-ASCII characters were detected in the grammar: ", nonAscii);
+          error_message_container.innerHTML = `<p>Non-ASCII character(s) detected: ${Array.from(nonAscii).join(", ")}</p>`;
+          error_message_container.style.display = "block";
+          diagram_container.style.display = "none";
+          return;
+        }
 
 				asyncGenerateDiagram(ebnfGrammarValue).then((diagram) =>
 				{

--- a/src/ChooChoo.ts
+++ b/src/ChooChoo.ts
@@ -141,3 +141,15 @@ export function base64UrlDecode(toDecode: string): string {
 	}
 	return atob(base64);
 }
+
+/**
+ * Check if a string is ASCII.
+ * @param str The string to check
+ * @param extended If `true`, the string can contain extended ASCII characters (0-255), otherwise only 0-127
+ * @returns
+ */
+export function getNonAsciiChars(str: string, extended: boolean = false): Set<string>  {
+	return new Set(str
+		.split('')
+		.filter(char => char.charCodeAt(0) > (extended ? 255 : 127)));
+}

--- a/src/Diagram.ts
+++ b/src/Diagram.ts
@@ -55,7 +55,7 @@ export class Diagram {
 		if (terms.length === 0) {
 			return first;
 		} else {
-			return rr.Choice( (terms.length + 1) / 2, first, ...terms);
+			return rr.Choice( Math.floor((terms.length + 1) / 2), first, ...terms);
 		}
 	}
 


### PR DESCRIPTION
Print warning when non-ASCII characters are used in grammar.
Properly calculate "normal" choice index for `Choice(…)`