### PR TITLE
Fix incorrect compaction

### DIFF
--- a/src/Diagram.ts
+++ b/src/Diagram.ts
@@ -113,8 +113,13 @@ export class Diagram {
 		// Check if all the content of the expression occurs before. I.e., can be compacted into a 1…n repetition instead of 0…n
 		let canBeCompacted = true;
 
+		// Don't support multiple terms in a repetition for compacting
 		if (repExpr.terms.length !== 1) {
-			// Don't support multiple terms in a repetition
+			canBeCompacted = false;
+		}
+
+		// Skip if the length of the repetition's expr stuff is longer than the index of the repetition expression
+		if (repExpr.terms[0].factors.length > repIdx) {
 			canBeCompacted = false;
 		}
 


### PR DESCRIPTION
If the expression in the repetition contained more terms than were before the repetition, it would compact, even when only a subset matched. 
E.g. `Dir { x Dir } Name` Would be compacted to a 1-to-n repetition of `{ x Dir } Name`

Before:
![railroad-diagram(2)](https://github.com/MrMinemeet/ebnf_railroad_visualizer/assets/31434466/ef7eecfd-371b-4b2d-9590-05ea887feff2)


After:
![railroad-diagram(1)](https://github.com/MrMinemeet/ebnf_railroad_visualizer/assets/31434466/ab2eaf83-c737-46e7-bfa4-86390af48818)
