### PR TITLE
Make CTRL+R-Click set startsymbol instead of expansion

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,26 +70,37 @@
           // Add a click event listener to the NTS to extend
           document.querySelectorAll(".non-terminal").forEach((element) => {
             element.addEventListener("click", (event) => {
-              // Get ID from inner child with tag "title"
-              const title = event.currentTarget.querySelector("title");
-              const pathTitle = title.textContent.trim();
 
-              if (pathTitle.length >= Diagram.MAX_EXPANSION_DEPTH) {
-                console.warn(`Cannot expand NTS on path '${pathTitle}'. Depth limit reached!`);
-                alert("Max. expansion depth reached!");
-                return;
+              if (event.ctrlKey) {
+                // Use the pressed NTS as the start symbol
+                const ntsName = event.currentTarget.querySelector("text").textContent;
+                const startSymbolSelect = document.querySelector("#start-symbol");
+                startSymbolSelect.value = ntsName;
+                handleStartSymbolSelection();
+                
+              } else {
+                // Get ID from inner child with tag "title"
+                const title = event.currentTarget.querySelector("title");
+                const pathTitle = title.textContent.trim();
+
+                // Expand the NTS
+                if (pathTitle.length >= Diagram.MAX_EXPANSION_DEPTH) {
+                  console.warn(`Cannot expand NTS on path '${pathTitle}'. Depth limit reached!`);
+                  alert("Max. expansion depth reached!");
+                  return;
+                }
+
+                // Add the ID to the set of non-terminals to extend
+                toExtend.add(title2Path(pathTitle));
+                console.debug(`Expanding NTS on path '${pathTitle}'`);
+
+                // Get "title" child of the clicked element and set the path as the focus element
+                focusElementPath = event.currentTarget.querySelector("title").innerHTML;
+
+                // Generate the diagram again
+                window.generateDiagram();
+                updateURL();
               }
-
-              // Add the ID to the set of non-terminals to extend
-              toExtend.add(title2Path(pathTitle));
-              console.debug(`Expanding NTS on path '${pathTitle}'`);
-
-              // Get "title" child of the clicked element and set the path as the focus element
-              focusElementPath = event.currentTarget.querySelector("title").innerHTML;
-
-              // Generate the diagram again
-              window.generateDiagram();
-              updateURL();
             });
           });
 

--- a/src/Diagram.ts
+++ b/src/Diagram.ts
@@ -20,7 +20,7 @@ export class Diagram {
 	// TODO: This is a workarround for now. The recursive detection is not yet implemented.
 	public static readonly MAX_EXPANSION_DEPTH: number = 30;
 
-	private readonly grammar: Grammar;
+	readonly grammar: Grammar;
 	private readonly pathStack: number[]; // Tracks the current path based on the sym.ids. E.g. [1, 3, 2] references the path from Sym with id 1 to sym with id 2 over sym with id 3
 	private expandingNtsPaths: number[][]; // Holds the paths for all NTS that should be expanded
 	private collectPaths: boolean;


### PR DESCRIPTION
If a NTS is clicked while CTRL is pressed, the NTS will be used as the Start Symbol.