### PR TITLE
Add CompressionStream compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ Try it out yourself with this [LINK](https://wtf-my-code.works/rr-diagram/?gramm
 ![Example railroad diagram with expanded NTS](./images/expanded_railroad_diagram.svg)  [Link to Example](https://wtf-my-code.works/rr-diagram/?grammar=UGF0aCA9IERpciB7IERpciB9IE5hbWUgLgpEaXIgPSAoIE5hbWUgfCAiLiIgWyAiLiIgXSApICIvIiAuCk5hbWUgPSBhbiB7IGFuIH0gLg&expand=MTItMTEtMTAtMi0xfDEyLTExLTEwLTktOA)
 
 * **URL Encoded Grammar:** Grammar is base64URL encoded into the URL. This allows for easy sharing of the current grammar by copying the URL or bookmarking it. The encoding also includes the list of expanded NTS.  
-The URL encoding also utilizes `lz-string` to compress the grammar and expand parameter in order to reduce their length. A size comparison was performed on the grammar for [MicroJava](https://www.ssw.jku.at/Misc/CC/Handouts.pdf) with the following results (character count):
+The URL encoding also utilizes GZip via `CompressionStream` to compress the grammar and expand parameter in order to reduce their length. Before `lz-string` was used, which is now being phased out in this project and only loaded on demand.  
+ A size comparison was performed on the grammar for [MicroJava](https://www.ssw.jku.at/Misc/CC/Handouts.pdf) with the following results:
 
-|Grammar|URL Encoded|Base64 Encoded|lz-string Compressed Base64|
-|-------|-----------|--------------|---------------------------|
-|   1241|       2305|          1656|                        916|
-|   100%|     185,7%|        133.4%|                      73,8%|
+|                    |Grammar|URL Encoded|Base64 Encoded|lz-string Compressed Base64|gzip Compressed Base64|
+|--------------------|-------|-----------|--------------|---------------------------|----------------------|
+|Size in Chars       |   1003|       1789|          1340|                        792|                   624|
+|Size rel. to Grammar|   100%|     178,4%|        133,4%|                      78,9%|                 62,2%|
 
 This only includes the grammar length, not the encoded expands. 
 
@@ -103,9 +104,10 @@ These can be set from another location to change the extended NTS or the start s
 
 ## Included Dependencies / Other Resources
 - [railroad.js](https://github.com/tabatkins/railroad-diagrams) by Tab Atkins Jr. et. al (with some modifications, see comment in the file at line ~16) | Provided as MIT (according to Github Repository) and CC0 (according to file itself)
-- [lz-string.js](https://github.com/pieroxy/lz-string) by pieroxy | Provided as MIT (according to Github Repository) and WTFPL (according to file itself)
+- [lz-string.js](https://github.com/pieroxy/lz-string) by pieroxy | Provided as MIT (according to Github Repository) and WTFPL (according to file itself) | **Phasing out**
 - [D3](https://github.com/d3/d3) by Mike Bostock et. al | Provided as ISC. **Optional dependency**
 - [github-mark.svg](https://github.com/logos) by GitHub. **Only used on website**
+
 ## License
 EBNF Railroad Diagram Visualizer © 2024 by Alexander Voglsperger is licensed under CC BY 4.0. To view a copy of this license, see [LICENSE](./LICENSE) or visit https://creativecommons.org/licenses/by/4.0/.
 

--- a/index.html
+++ b/index.html
@@ -4,94 +4,94 @@ To view a copy of this license, see the provided LICENSE file or visit https://c
 -->
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>EBNF Railroad Visualizer</title>
-    <meta charset="UTF-8">
-    <meta name="description" content="A visualizer for EBNF grammars using railroad diagrams.">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="author" content="Alexander Voglsperger">
-    <meta name="keywords" content="EBNF, Railroad, Visualizer, Diagram, Syntax, Notation, Wirth, Grammar, Extended, Backus, Naur, Form, Tool, Generator">
-    <link rel="icon" href="./images/favicon.svg" />
-    <link rel="stylesheet" type="text/css" href="./css/railroad.css">
-    <link rel="stylesheet" href="./css/styles.css">
-    <meta property="og:title" content="EBNF Railroad Visualizer">
-    <meta property="og:description" content="A visualizer for EBNF grammars using railroad diagrams.">
-    <meta property="og:image" content="https://wtf-my-code.works/rr-diagram/images/og-image.png">
-    <meta property="og:url" content="https://wtf-my-code.works/rr-diagram/">
-    <meta property="og:type" content="website">
-    <script type="module">
-      import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
-      import { install } from "./out/ChooChoo.js";
-      install(window, d3);
-    </script>
-  </head>
-  <body>
-    <div class="flex-container">
-      <div class="flex-item">
-        <h1>EBNF Visualizer</h1>
-        <a loading="lazy" id="repository_reference" href="https://github.com/MrMinemeet/ebnf_railroad_visualizer" target="_blank"><img src="./images/github-mark.svg" alt="GitHub Invertocat linking to the repository"></a>
-      </div>
-      <div class="wayback-machine-warning" style="display:none">
-        <p>This website seems to be a snapshot from the WayBack Machine. It may not work as expected.</p>
-        <p>Please visit <a href="https://wtf-my-code.works/rr-diagram/">wtf-my-code.works/rr-diagram</a> or use the backup hosted on <a href="https://mrminemeet.github.io/ebnf_railroad_visualizer/">GitHub Pages</a>.</p>
-      </div>
-      <div class="flex-item">
-        <h2>Grammar</h2>
-        <textarea autofocus="true" id="userInput" name="ebnf_grammar" placeholder="EBNF-Grammar in Wirth Syntax Notation" oninput="handleGenerateDiagram()"></textarea>
-        <div id="error_message">
-          <!-- Error message will be inserted here -->
-        </div>
-      </div>
-      <div class="flex-item">
-        <h2>Railroad Diagram</h2>
-        <div class="start-symbol-drop-down controls" style="display: none;">
-          <label for="start-symbol">Start symbol:</label>
-          <select name="start-symbol" id="start-symbol" onchange="handleStartSymbolSelection()">
-            <!-- Start symbols will be inserted here -->
-          </select>
-        </div>
-        <div class="controls">
-          <button onclick="onExpandAll();">Expand All</button>
-          <button onclick="onCollapseAll();">Collapse All</button>
-          <button id="export-as-svg" onclick="exportSvg(window.toExtend);">Export as SVG</button>
-          <button id="export-as-png" onclick="exportPng(window.toExtend);">Export as PNG</button>
-        </div>
-      </div>
-      <div class="flex-item" id="visualized-ebnf">
-        <!-- Diagram will be inserted here -->
-      </div>
-    </div>
-    <script type="module">
-      // Show warning if the website is a snapshot from Internet Archive's Wayback Machine
-      if (window.location.hostname.includes("web.archive.org")) {
-        document.querySelector(".wayback-machine-warning").style.display = "block";
-      }
-    </script>
+	<head>
+		<title>EBNF Railroad Visualizer</title>
+		<meta charset="UTF-8">
+		<meta name="description" content="A visualizer for EBNF grammars using railroad diagrams.">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="author" content="Alexander Voglsperger">
+		<meta name="keywords" content="EBNF, Railroad, Visualizer, Diagram, Syntax, Notation, Wirth, Grammar, Extended, Backus, Naur, Form, Tool, Generator">
+		<link rel="icon" href="./images/favicon.svg" />
+		<link rel="stylesheet" type="text/css" href="./css/railroad.css">
+		<link rel="stylesheet" href="./css/styles.css">
+		<meta property="og:title" content="EBNF Railroad Visualizer">
+		<meta property="og:description" content="A visualizer for EBNF grammars using railroad diagrams.">
+		<meta property="og:image" content="https://wtf-my-code.works/rr-diagram/images/og-image.png">
+		<meta property="og:url" content="https://wtf-my-code.works/rr-diagram/">
+		<meta property="og:type" content="website">
+		<script type="module">
+			import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
+			import { install } from "./out/ChooChoo.js";
+			install(window, d3);
+		</script>
+	</head>
+	<body>
+		<div class="flex-container">
+			<div class="flex-item">
+				<h1>EBNF Visualizer</h1>
+				<a loading="lazy" id="repository_reference" href="https://github.com/MrMinemeet/ebnf_railroad_visualizer" target="_blank"><img src="./images/github-mark.svg" alt="GitHub Invertocat linking to the repository"></a>
+			</div>
+			<div class="wayback-machine-warning" style="display:none">
+				<p>This website seems to be a snapshot from the WayBack Machine. It may not work as expected.</p>
+				<p>Please visit <a href="https://wtf-my-code.works/rr-diagram/">wtf-my-code.works/rr-diagram</a> or use the backup hosted on <a href="https://mrminemeet.github.io/ebnf_railroad_visualizer/">GitHub Pages</a>.</p>
+			</div>
+			<div class="flex-item">
+				<h2>Grammar</h2>
+				<textarea autofocus="true" id="userInput" name="ebnf_grammar" placeholder="EBNF-Grammar in Wirth Syntax Notation" oninput="handleGenerateDiagram()"></textarea>
+				<div id="error_message">
+					<!-- Error message will be inserted here -->
+				</div>
+			</div>
+			<div class="flex-item">
+				<h2>Railroad Diagram</h2>
+				<div class="start-symbol-drop-down controls" style="display: none;">
+					<label for="start-symbol">Start symbol:</label>
+					<select name="start-symbol" id="start-symbol" onchange="handleStartSymbolSelection()">
+						<!-- Start symbols will be inserted here -->
+					</select>
+				</div>
+				<div class="controls">
+					<button onclick="onExpandAll();">Expand All</button>
+					<button onclick="onCollapseAll();">Collapse All</button>
+					<button id="export-as-svg" onclick="exportSvg(window.toExtend);">Export as SVG</button>
+					<button id="export-as-png" onclick="exportPng(window.toExtend);">Export as PNG</button>
+				</div>
+			</div>
+			<div class="flex-item" id="visualized-ebnf">
+				<!-- Diagram will be inserted here -->
+			</div>
+		</div>
+		<script type="module">
+			// Show warning if the website is a snapshot from Internet Archive's Wayback Machine
+			if (window.location.hostname.includes("web.archive.org")) {
+				document.querySelector(".wayback-machine-warning").style.display = "block";
+			}
+		</script>
 
-    <script type="module" async defer>
-      import { getValuesFromUrl } from "./out/ChooChoo.js";
-      
-      // Async defer is not a guarantee that the DOM is ready. The following event does.
-      // document.addEventListener("DOMContentLoaded", function() { // Doesn't work reliably in Chrome
-      document.onreadystatechange = function() {
-        if (document.readyState !== "complete") return;
+		<script type="module" async defer>
+			import { getValuesFromUrl } from "./out/ChooChoo.js";
+			
+			// Async defer is not a guarantee that the DOM is ready. The following event does.
+			// document.addEventListener("DOMContentLoaded", function() { // Doesn't work reliably in Chrome
+			document.onreadystatechange = async function() {
+				if (document.readyState !== "complete") return;
 
-        console.info("Retrieving data from URL parameters…");
-        // Try to get grammar from URL
-        const [ grammar, urlExpand, startSymbolName ] = getValuesFromUrl(window.location.search);
+				console.info("Retrieving data from URL parameters…");
+				// Try to get grammar from URL
+				const [ grammar, urlExpand, startSymbolName ] = await getValuesFromUrl(window.location.search);
 
-        // Update grammar and expand numbers
-        document.querySelector("textarea[name=ebnf_grammar]").value = grammar;
-        window.chooChoo.toExtend = urlExpand;
-        window.chooChoo.currentStartSymbolName = startSymbolName;
+				// Update grammar and expand numbers
+				document.querySelector("textarea[name=ebnf_grammar]").value = grammar;
+				window.chooChoo.toExtend = urlExpand;
+				window.chooChoo.currentStartSymbolName = startSymbolName;
 
-        if (grammar !== "") {
-          console.info("Generating diagram from URL parameters…");
-          /* Try to generate when grammar is not empty. 
-          The other two values do not make sense to generate a diagram, if the grammar is empty. */
-          window.generateDiagram();
-        }
-      };
-    </script>
-  </body>
+				if (grammar !== "") {
+					console.info("Generating diagram from URL parameters…");
+					/* Try to generate when grammar is not empty. 
+					The other two values do not make sense to generate a diagram, if the grammar is empty. */
+					window.generateDiagram();
+				}
+			};
+		</script>
+	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A web-based EBNF railroad diagram visualizer",
   "homepage": "https://github.com/MrMinemeet/ebnf_railroad_visualizer",
   "license": "CC-BY-4.0",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "Alexander Voglsperger",
     "email": "alex@wtf-my-code.works",

--- a/src/Compressor.ts
+++ b/src/Compressor.ts
@@ -1,0 +1,70 @@
+/*
+ * This work © 2024 by Alexander Voglsperger is licensed under CC BY 4.0.
+ * To view a copy of this license, see the provided LICENSE file or visit https://creativecommons.org/licenses/by/4.0/
+ */
+
+/**
+ * Compresses a string using the specified compression format, which is "gzip" by default.
+ * @param input The string to compress
+ * @param format The compression format to use (default: gzip)
+ * @returns The compressed data as Uint8Array
+ */
+async function compressString(input: string, format: CompressionFormat = "gzip"): Promise<Uint8Array> {
+	const inputBytes = new TextEncoder().encode(input);
+
+	const stream = new CompressionStream(format);
+	const writer = stream.writable.getWriter();
+
+	// Put input bytes through the compression stream via writer
+	writer.write(inputBytes);
+	writer.close();
+
+	// Response allows convertion of readable stream to an ArrayBuffer
+	const compressedDataBuffer = await new Response(stream.readable).arrayBuffer();
+	return new Uint8Array(compressedDataBuffer);
+}
+
+/**
+ * Compresses and base64-encodes a string using the specified compression format.
+ * @param input The string to compress and encode
+ * @param format The compression format to use (default: gzip)
+ * @returns The compressed and encoded data as a base64 string
+ */
+export async function compressAndEncode(input: string, format: CompressionFormat = "gzip"): Promise<string> {
+	console.debug("Compressing and encoding data...");
+	const compressedData = await compressString(input, format);
+	return btoa(String.fromCharCode(...compressedData));
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+/**
+ * Decodes and decompresses a base64-encoded string.
+ * @param input The compressed and base64-encoded data
+ * @param format The compression format to use (default: gzip)
+ * @returns The decompressed data as a string
+ */
+export async function decodeAndDecompress(input: string, format: CompressionFormat = "gzip"): Promise<string> {
+	console.debug("Decoding and decompressing data...");
+	const compressedData = atob(input);
+	const compressedByteArray = new Uint8Array(compressedData.length);
+	for (let i = 0; i < compressedData.length; i++) {
+		compressedByteArray[i] = compressedData.charCodeAt(i);
+	}
+	return await decompressString(compressedByteArray, format);
+}
+
+/**
+ * Decompresses a Uint8Array using the specified compression format.
+ * @param input The compressed data
+ * @param format The compression format to use (default: gzip)
+ * @returns The decompressed data as a string
+ */
+async function decompressString(input: Uint8Array, format: CompressionFormat = "gzip"): Promise<string> {
+	const stream = new DecompressionStream(format);
+	const writer = stream.writable.getWriter();
+	writer.write(input);
+	writer.close();
+
+	const decompressedDataBuffer = await new Response(stream.readable).arrayBuffer();
+	return new TextDecoder().decode(decompressedDataBuffer);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    /*"module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "ES2020",                                  /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
The [compression stream](https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API) uses `gzip` which is, as of now, the new default for the visualizer. The main point is to reduce external dependencies, especially when a simpler way exists with a better result (as of [bench-marking](https://github.com/MrMinemeet/ebnf_railroad_visualizer/commit/8d8761ca045a1a4023b061d6cda326102b8b8583#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40-R43))

Decompression of URLs that contain [lz-string](https://github.com/pieroxy/lz-string) compressed data is still supported for the foreseeable future, but may be removed. The dependency is loaded on demand.
